### PR TITLE
Add support for Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ jobs:
   include:
     - stage: Tests
       name: Linting
-      python: 3.7
+      python: 3.8
       env: TOXENV=linting
 
     -
@@ -19,6 +19,10 @@ jobs:
       env: TOXENV=py37
 
     -
+      python: 3.8
+      env: TOXENV=py38
+
+    -
       python: pypy
       env: TOXENV=pypy
 
@@ -27,7 +31,7 @@ jobs:
       env: TOXENV=pypy3
 
     - stage: deploy
-      python: 3.7
+      python: 3.8
       install: skip
       script: skip
       deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ jobs:
     - stage: Tests
       name: Linting
       python: 3.7
-      dist: xenial
-      sudo: required
       env: TOXENV=linting
 
     -
@@ -18,8 +16,6 @@ jobs:
 
     -
       python: 3.7
-      dist: xenial
-      sudo: required
       env: TOXENV=py37
 
     -
@@ -32,8 +28,6 @@ jobs:
 
     - stage: deploy
       python: 3.7
-      dist: xenial
-      sudo: required
       install: skip
       script: skip
       deploy:

--- a/README.rst
+++ b/README.rst
@@ -25,9 +25,9 @@ access to test session metadata.
 Requirements
 ------------
 
-You will need the following prerequisites in order to use pytest-metadata:
+You will need the following in order to use pytest-metadata:
 
-- Python 2.7, 3.6, PyPy, or PyPy3
+- Python 2.7, 3.6+, PyPy, or PyPy3
 
 Installation
 ------------

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(
     install_requires=["pytest>=2.9.0"],
     license="Mozilla Public License 2.0 (MPL 2.0)",
     keywords="py.test pytest metadata",
+    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Framework :: Pytest",
@@ -26,8 +27,11 @@ setup(
         "Topic :: Software Development :: Testing",
         "Topic :: Utilities",
         "Programming Language :: Python",
+        "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,36,37,py,py3}, linting
+envlist = py{27,36,37,38,py,py3}, linting
 
 [testenv]
 setenv = PYTHONDONTWRITEBYTECODE=1


### PR DESCRIPTION
And adds `python_requires` to help pip.

Also the `sudo` keyword no longer has any effect on Travis CI, and Xenial is the default.