### PR TITLE
pytest-xdist 2.0 compatibility

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -5,3 +5,4 @@ Imran Mumtaz
 Jim Brännlund
 Sam Clements
 Tomas Krizek
+Zac Hatfield-Dodds

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 Release Notes
 -------------
 
+* Compatible with ``pytest-xdist`` 1.22.3+, now including 2.0+
+
+  * Thanks to `@Zac-HD <https://github.com/Zac-HD>`_ for the PR
+
 1.9.0 (2020-04-03)
 ------------------
 

--- a/pytest_metadata/plugin.py
+++ b/pytest_metadata/plugin.py
@@ -93,8 +93,8 @@ def pytest_configure(config):
             if os.environ.get(var)
         ]
 
-    if hasattr(config, "slaveoutput"):
-        config.slaveoutput["metadata"] = config._metadata
+    if hasattr(config, "workeroutput"):
+        config.workeroutput["metadata"] = config._metadata
 
     config.hook.pytest_metadata(metadata=config._metadata)
 
@@ -106,7 +106,7 @@ def pytest_report_header(config):
 
 @pytest.mark.optionalhook
 def pytest_testnodedown(node):
-    # note that any metadata from remote slaves will be replaced with the
-    # environment from the final slave to quit
-    if hasattr(node, "slaveoutput"):
-        node.config._metadata.update(node.slaveoutput["metadata"])
+    # note that any metadata from remote workers will be replaced with the
+    # environment from the final worker to quit
+    if hasattr(node, "workeroutput"):
+        node.config._metadata.update(node.workeroutput["metadata"])


### PR DESCRIPTION
The "slave-" attributes are removed after a period of deprecation in favor of "worker-" attributes.  See https://github.com/pytest-dev/pytest-xdist/pull/541... @BeyondEvil, you know the drill by now :laughing: 