### PR TITLE
Include metadata in junit xml results as property tags

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Release Notes
 -------------
 
+1.11.0 (unreleased)
+-------------------
+
+* Provide a session fixture to include metadata in Junit XMLs as property tags.
+
 1.10.0 (2020-06-24)
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -107,6 +107,38 @@ metadata will be displayed in the terminal report header::
   metadata: {'Python': '3.6.4', 'Platform': 'Darwin-17.4.0-x86_64-i386-64bit', 'Packages': {'pytest': '3.4.1', 'py': '1.5.2', 'pluggy': '0.6.0'}, 'Plugins': {'metadata': '1.6.0'}}
   plugins: metadata-1.6.0
 
+Including metadata in Junit XML
+-------------------------------
+
+Pytest-metadata provides the session scoped fixture :code:`include_metadata_in_junit_xml` that you may use to include any metadata in Junit XML as ``property`` tags.
+For example the following test module
+
+.. code-block:: python
+
+  import pytest
+
+  pytestmark = pytest.mark.usefixtures('include_metadata_in_junit_xml')
+
+  def test():
+      pass
+
+when called with
+
+.. code-block:: bash
+
+  pytest --metadata Daffy Duck --junit-xml=results.xml
+
+would produce the following XML
+
+.. code-block:: xml
+
+  <?xml version="1.0" encoding="utf-8"?>
+  <testsuites>
+    <testsuite name="pytest" errors="0" failures="0" skipped="0" tests="1" time="0.009" timestamp="2020-11-27T06:38:44.407674" hostname="sam">
+      <properties>
+        <property name="Daffy" value="Duck"/>
+  ...
+
 Accessing metadata
 ------------------
 

--- a/pytest_metadata/plugin.py
+++ b/pytest_metadata/plugin.py
@@ -45,6 +45,14 @@ def metadata(pytestconfig):
     return pytestconfig._metadata
 
 
+@pytest.fixture(scope="session")
+def include_metadata_in_junit_xml(metadata, pytestconfig, record_testsuite_property):
+    """Provide test session metadata"""
+    metadata_ = pytestconfig._metadata
+    for name, value in metadata_.items():
+        record_testsuite_property(name, value)
+
+
 def pytest_addoption(parser):
     parser.addoption(
         "--metadata",

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,6 +1,8 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+import pytest
+from xml.etree import ElementTree as ET
 
 pytest_plugins = ("pytester",)
 
@@ -42,6 +44,36 @@ def test_additional_metadata(testdir):
     )
     result = testdir.runpytest("--metadata", "Dave", "Hunt", "--metadata", "Jim", "Bob")
     assert result.ret == 0
+
+
+@pytest.mark.parametrize("junit_format", ["xunit1", "xunit2"])
+def test_junit_integration(testdir, junit_format):
+    testdir.makepyfile(
+        """
+        import pytest
+
+        pytestmark = pytest.mark.usefixtures('include_metadata_in_junit_xml')
+
+        def test_pass():
+            pass
+    """
+    )
+    result = testdir.runpytest(
+        "--metadata",
+        "Daffy",
+        "Duck",
+        "--junit-xml=results.xml",
+        "--override-ini='junit_family={}'".format(junit_format),
+    )
+    assert result.ret == 0
+    results_file = testdir.tmpdir.join("results.xml")
+    assert results_file.exists()
+    with results_file.open() as fd:
+        xml = ET.parse(fd)
+    properties = xml.findall(".//property")
+    xml_metadata = [p.attrib for p in properties]
+    # value passed on the cmdline appears
+    assert {"name": "Daffy", "value": "Duck"} in xml_metadata
 
 
 def test_additional_metadata_from_json(testdir):


### PR DESCRIPTION
By adding an autoused session fixture that calls record_testsuite_property.

A couple of questions about this.

To my understanding `<property>` tags aren't supported in xunit1 format - however this feels like something that pytest itself should be looking after rather than checking that in this plugin (i.e. `record_testsuite_property` should be a null op in that case, or raise or something).

This only handles the session-level metadata. TBH, that's all I need and it's useful in itself.

I suppose that this could/should be noted in the docs somewhere (should it?). I couldn't decide where to reasonably mention this.