### PR TITLE
Option to read metadata from a JSON file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -74,6 +74,10 @@ There's also the possibility of passing in metadata as a JSON string::
 
     pytest --metadata-from-json '{"cat_says": "bring the cat nip", "human_says": "yes kitty"}'
 
+Alternatively a JSON can be read from a given file::
+
+    pytest --metadata-from-json-file path/to/valid/file.json
+
 Continuous integration
 ----------------------
 

--- a/pytest_metadata/plugin.py
+++ b/pytest_metadata/plugin.py
@@ -93,7 +93,7 @@ def pytest_configure(config):
     config._metadata.update(json.loads(config.getoption("metadata_from_json")))
     if config.getoption("metadata_from_json_file"):
         with open(config.getoption("metadata_from_json_file"), "r") as json_file:
-            config._metadata.update(json.loads(json_file.read()))
+            config._metadata.update(json.load(json_file))
     plugins = dict()
     for plugin, dist in config.pluginmanager.list_plugin_distinfo():
         name, version = dist.project_name, dist.version

--- a/pytest_metadata/plugin.py
+++ b/pytest_metadata/plugin.py
@@ -70,6 +70,12 @@ def pytest_addoption(parser):
         dest="metadata_from_json",
         help="additional metadata from a json string.",
     )
+    parser.addoption(
+        "--metadata-from-json-file",
+        type=str,
+        dest="metadata_from_json_file",
+        help="additional metadata from a json file.",
+    )
 
 
 @pytest.hookimpl(tryfirst=True)
@@ -85,7 +91,9 @@ def pytest_configure(config):
     }
     config._metadata.update({k: v for k, v in config.getoption("metadata")})
     config._metadata.update(json.loads(config.getoption("metadata_from_json")))
-
+    if config.getoption("metadata_from_json_file"):
+        with open(config.getoption("metadata_from_json_file"), "r") as json_file:
+            config._metadata.update(json.loads(json_file.read()))
     plugins = dict()
     for plugin, dist in config.pluginmanager.list_plugin_distinfo():
         name, version = dist.project_name, dist.version

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -96,7 +96,7 @@ def test_additional_metadata_from_json_file(testdir):
     """
     )
 
-    json_temp = NamedTemporaryFile()
+    json_temp = NamedTemporaryFile(delete=False)
     json_temp.write('{"John": "Cena"}'.encode(encoding="utf-8"))
     json_temp.flush()
     result = testdir.runpytest("--metadata-from-json-file", json_temp.name)
@@ -112,7 +112,7 @@ def test_additional_metadata_using_key_values_json_str_and_file(testdir):
             assert metadata.get('Andre') == 'The Giant'
     """
     )
-    json_temp = NamedTemporaryFile()
+    json_temp = NamedTemporaryFile(delete=False)
     json_temp.write('{"Andre": "The Giant"}'.encode(encoding="utf-8"))
     json_temp.flush()
     result = testdir.runpytest(


### PR DESCRIPTION
This change adds an option to provide user-defined metadata from a file which is expected to have a valid JSON inside.

There is already a way to give JSON as a string (`--metadata-from-json`) parameter, but it requires presence of both `'` and `"` indicators. Now if one would like to pass such metadata string through multiple shell scripts and utilities all of them would have to respect quotations carefully before they land in eventual `pytest` call. With a JSON file this problem would just go away given the file has no spaces inside the name.