### PR TITLE
Beyondevil/tmpdir workaround

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   publish:
-    if: github.repository == 'pytest-dev/pytest-base-url'
+    if: github.repository == 'pytest-dev/pytest-metadata'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/src/pytest_metadata/plugin.py
+++ b/src/pytest_metadata/plugin.py
@@ -94,6 +94,7 @@ def pytest_configure(config):
     config.stash[metadata_key].update(
         json.loads(config.getoption("metadata_from_json"))
     )
+
     if config.getoption("metadata_from_json_file"):
         with open(config.getoption("metadata_from_json_file"), "r") as json_file:
             config.stash[metadata_key].update(json.load(json_file))


### PR DESCRIPTION
Implemented the suggested workaround (3) here: https://github.com/pytest-dev/pytest/issues/11781#issuecomment-1879825223

Also, replace the deprecated "testdir" with "pytester".