### PR TITLE
Fix license classifier in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Framework :: Pytest",
   "Intended Audience :: Developers",
-  "License :: OSI Approved :: MIT License",
+  "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)",
   "Natural Language :: English",
   "Operating System :: POSIX",
   "Operating System :: Microsoft :: Windows",


### PR DESCRIPTION
Project is licensed as MPL-2.0 but a MIT license classifier is being used, resulting in the wrong license being displayed on PyPI. Changing classifier to the correct one for the actual project license.