### PR TITLE
Dropped old pytest version compatibility

### DIFF
--- a/src/pytest_metadata/plugin.py
+++ b/src/pytest_metadata/plugin.py
@@ -5,10 +5,7 @@ import json
 import os
 import platform
 
-try:
-    import _pytest._pluggy as pluggy
-except ImportError:
-    import pluggy
+import pluggy
 import pytest
 
 from pytest_metadata.ci import (


### PR DESCRIPTION
The vendoring this import covered disappeared in Pytest 3.3.0